### PR TITLE
Multi process support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -39,7 +39,7 @@ Pass version files to the `build` script to build specific versions:
 With `parallel` available you can speed up building a bit:
 
 ```sh
-parallel -m ./build ::: version/**/options
+parallel -m ./build ::: versions/**/options
 ```
 
 ## Testing

--- a/builder/scripts/mkimage-phan.bash
+++ b/builder/scripts/mkimage-phan.bash
@@ -40,7 +40,7 @@ build() {
 
   # install runtime dependencies into rootfs
   {
-    apk --no-cache --root "$rootfs" --keys-dir /etc/apk/keys add --initdb php7@testing php7-json@testing php7-sqlite3@testing php7-mbstring@testing tini@community
+    apk --no-cache --root "$rootfs" --keys-dir /etc/apk/keys add --initdb php7@testing php7-json@testing php7-sqlite3@testing php7-mbstring@testing php7-pcntl@testing tini@community
     cp /docker-entrypoint.sh "$rootfs"/docker-entrypoint.sh
   } >&2
 
@@ -55,7 +55,7 @@ build() {
     fi
     cd phan
 
-    php7 /usr/local/bin/composer.phar --no-dev --ignore-platform-reqs --no-interaction install
+    php7 /usr/local/bin/composer.phar --prefer-dist --no-dev --ignore-platform-reqs --no-interaction install
     rm -rf .git
   } >&2
 


### PR DESCRIPTION
In order to speed the actual analysis up a bit further phan has support for parralel processing.

This change includes support for this by building the image with `pcntl` support
