### PR TITLE
Fixes #10. Added Travic CI build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: bash
+sudo: required
+services:
+  - docker
+script:
+  - ./build versions/edge/options
+after_success:
+  - ./build test versions/edge/options
+deploy:
+  provider: script
+  script: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && ./build push versions/edge/options
+  on:
+    branch: master


### PR DESCRIPTION
This should be configured in Travis before merge, but it allows to build the edge version by cron from travis, with auto update on docker.

The `DOCKER_USERNAME` & `DOCKER_PASSWORD` should be configured as protected variables in Travis, and I would recommend a weekly cron (see attached screenshot).

![image](https://user-images.githubusercontent.com/1835343/30455804-8d1e8258-99a1-11e7-89e2-846238339e81.png)

Note: I'm waiting on the final build to finish, will let you know when it should work.