### PR TITLE
Update dependencies

### DIFF
--- a/builder/scripts/mkimage-phan.bash
+++ b/builder/scripts/mkimage-phan.bash
@@ -36,6 +36,8 @@ build() {
   # install composer
   {
     cd /tmp
+    apk --no-cache add ca-certificates openssl wget
+    update-ca-certificates
     EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
     php7 -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
     ACTUAL_SIGNATURE=$(php7 -r "echo hash_file('SHA384', 'composer-setup.php');")

--- a/builder/scripts/mkimage-phan.bash
+++ b/builder/scripts/mkimage-phan.bash
@@ -72,7 +72,7 @@ build() {
   # install php-ast
   {
     cd /tmp
-    git clone -b "v0.1.1" --single-branch --depth 1 https://github.com/nikic/php-ast.git
+    git clone -b "v0.1.5" --single-branch --depth 1 https://github.com/nikic/php-ast.git
     cd php-ast
     phpize7
     ./configure --with-php-config=php-config7


### PR DESCRIPTION
* Updated composer to the newest stable version (by using their install script)
* Updated ast to the newest version (as the image wouldn't build without it, probably due to Phan updates)
* Install PHP before composer, to be able to use PHP to install composer