### PR TITLE
Delete unused test cases

### DIFF
--- a/builder/scripts/mkimage-phan.bash
+++ b/builder/scripts/mkimage-phan.bash
@@ -56,6 +56,7 @@ build() {
 
     php7 /usr/local/bin/composer.phar --prefer-dist --no-dev --ignore-platform-reqs --no-interaction install
     rm -rf .git
+    rm -rf tests vendor/symfony/console/Tests vendor/symfony/debug/Tests ./vendor/symfony/debug/Resources/ext/tests
   } >&2
 
   # install php-ast


### PR DESCRIPTION
Even though --prefer-dist is used, the test folders of symfony still
show up.

Nothing in `/opt/phan/tests/` is needed to invoke Phan on an
external project in /mnt/src.
These take up 0.5 MB in the final image(19.6 vs 20.1 MB)