### PR TITLE
Allow for overriding the workdir on runtime

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -3,4 +3,5 @@ COPY scripts/mkimage-phan.bash /
 COPY scripts/docker-entrypoint.sh /
 RUN apk --no-cache add bash
 RUN apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini
+WORKDIR /mnt/src
 ENTRYPOINT ["/sbin/tini", "-g", "--", "/mkimage-phan.bash"]

--- a/builder/scripts/docker-entrypoint.sh
+++ b/builder/scripts/docker-entrypoint.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-cd /mnt/src
 exec php7 /opt/phan/phan "$@"


### PR DESCRIPTION
This way you can set the workdir at runtime, eg:
`docker run -v $PWD:/mnt/src -w /mnt/src/my/module/dir --rm cloudflare/phan:edge phan`